### PR TITLE
import backend only when available in the environment

### DIFF
--- a/src/multinterp/backend/__init__.py
+++ b/src/multinterp/backend/__init__.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 
-from multinterp.backend._cupy import cupy_multinterp
-from multinterp.backend._jax import jax_multinterp
-from multinterp.backend._numba import numba_multinterp
-from multinterp.backend._scipy import scipy_multinterp
+backend_functions = {}
+try:
+    from multinterp.backend._cupy import cupy_multinterp
+    backend_functions["cupy"] = cupy_multinterp
+except:
+    pass
 
-backend_functions = {
-    "scipy": scipy_multinterp,
-    "numba": numba_multinterp,
-    "cupy": cupy_multinterp,
-    "jax": jax_multinterp,
-}
+try:
+    from multinterp.backend._cupy import jax_multinterp
+    backend_functions["jax"] = jax_multinterp
+except:
+    pass
+
+try:
+    from multinterp.backend._cupy import numba_multinterp
+    backend_functions["numba"] = numba_multinterp
+except:
+    pass
+
+try:
+    from multinterp.backend._cupy import scipy_multinterp
+    backend_functions["scipy"] = scipy_multinterp
+except:
+    pass
 
 
 def multinterp(grids, values, args, backend="numba"):

--- a/src/multinterp/backend/__init__.py
+++ b/src/multinterp/backend/__init__.py
@@ -3,24 +3,28 @@ from __future__ import annotations
 backend_functions = {}
 try:
     from multinterp.backend._cupy import cupy_multinterp
+
     backend_functions["cupy"] = cupy_multinterp
 except:
     pass
 
 try:
     from multinterp.backend._cupy import jax_multinterp
+
     backend_functions["jax"] = jax_multinterp
 except:
     pass
 
 try:
     from multinterp.backend._cupy import numba_multinterp
+
     backend_functions["numba"] = numba_multinterp
 except:
     pass
 
 try:
     from multinterp.backend._cupy import scipy_multinterp
+
     backend_functions["scipy"] = scipy_multinterp
 except:
     pass

--- a/src/multinterp/regular.py
+++ b/src/multinterp/regular.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
-import cupy as cp
-import jax.numpy as jnp
+
 import numpy as np
+
+try:
+    import cupy as cp
+except ImportError:
+    pass
+
+try:
+    import jax.numpy as jnp
+except ImportError:
+    pass
 
 from multinterp.backend._numba import numba_get_coordinates, numba_map_coordinates
 from multinterp.backend._scipy import scipy_get_coordinates, scipy_map_coordinates


### PR DESCRIPTION
@alanlujan91 I haven't tested this, but you would need to do something like this to make sure you don't trip up the `cupy` `jax` imports in the backend files.